### PR TITLE
Fixing problems with MATLAB's numerical sqrtm

### DIFF
--- a/Fidelity.m
+++ b/Fidelity.m
@@ -46,6 +46,7 @@ if(isa(rho,'cvx') || isa(sigma,'cvx'))
 % since this is much faster.
 else
     [sq_rho,res] = sqrtm(rho); % need "res" parameter to suppress MATLAB singularity warning
-    [sq_fid,res] = sqrtm(sq_rho*sigma*sq_rho);
+    sq_prod = sq_rho*sigma*sq_rho;
+    [sq_fid,res] = sqrtm((sq_prod+sq_prod')/2); % needed to avoid numerical problems
     fid = real(trace(sq_fid)); % finally, compute the fidelity
 end


### PR DESCRIPTION
The current code runs into some problems when `sqrtm` is not able to compute the square root in the final step of evaluating the fidelity for numerical (non-CVX) matrices. Consider the following example:

```
>> rho = pure_to_mixed([sqrt(0.6); -sqrt(0.4)*i]);
>> b = pure_to_mixed([1; 0]);
>> Fidelity(Tensor(b,rho), Tensor(rho,b))

ans =

   NaN
```

More generally, running `Fidelity(Tensor(b, RandomDensityMatrix(2)), Tensor(RandomDensityMatrix(2), b))` results in `NaN` in most cases.

This is solved here by explicitly making the operator Hermitian.