### PR TITLE
Fix bugs and docs in `IskIncoherent.m`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,10 @@ All notable changes to QETLAB will be documented in this file.
 - helpers/exp2ind: Looks up a monomial's lexicographical index based on a list of exponents.
 - helpers/fc2fp: Converts a Bell functional or behaviour in full correlator notation and converts it to full probability notation. Used in BellInequalityMax.m.
 - helpers/fc2cg: Converts a Bell functional or behaviour in full correlator notation and converts it to Collins-Gisin notation. Used in BellInequalityMax.m.
-- helpers/ffl: Produces the coefficients of the Fortnow-Feige-Lovász nonlocal game. Can be used as a test case for BellInequalityMax.
+- helpers/ffl: Produces the coefficients of the Fortnow-Feige-Lovï¿½sz nonlocal game. Can be used as a test case for BellInequalityMax.
 - helpers/fp2fc: Converts a Bell functional or behaviour in full probability notation and converts it to full correlator notation. Used in BellInequalityMax.m.
 - helpers/fp2cg: Converts a Bell functional or behaviour in full probability notation and converts it to Collins-Gisin notation. Used in BellInequalityMax.m.
+- helpers/has_band_k_ordering: Determines whether a matrix has bandwidth â‰¤ k up to symmetric permutation. Used as a new helper check in IskIncoherent.m.
 - helpers/glob_ind: Creates a global index from a vector of local indices. Used to be bundled inside of SymmetricProjection.m.
 - helpers/pad_array: Pads an array with zeroes. Replaces padarray from the Image Processing toolbox.
 - helpers/poly_rand_input: Evaluates a homogeneous polynomial on a random input from the unit sphere.
@@ -45,6 +46,7 @@ All notable changes to QETLAB will be documented in this file.
 - Entropy: Improved numerical stability so that it no longer frequently returns NaN output.
 - GHZState: Now accepts DIM = 1 and/or Q = 1 as input.
 - IsBlockPositive: Fixed a numerical tolerance error that would sometimes cause incorrect results to be reported.
+- IskIncoherent: Fixed bug with nested CVX optimization and added a bandwidth check to sometimes return early. (Also fixed documentation.)
 - IsSeparable: Fixed a numerical tolerance error that would sometimes cause incorrect results to be reported.
 - Negativity: Users can now input either a pure state vector or a density matrix (previously, only density matrices were accepted).
 - NonlocalGameValue: Now computes classical value of a game quicker, via algorithm of arXiv:2005.13418

--- a/IskIncoherent.m
+++ b/IskIncoherent.m
@@ -3,17 +3,18 @@
 %     X: a density matrix
 %     k: a positive integer, the coherence level to check for
 %
-%   IKI = ISKINCOHERENT(X, K) returns 1 if X is k-incoherent, 0 if X is not
-%   k-incoherent, and -1 if the function cannot determine if X is k-incoherent
-%   or not.
+%
+%   IKI = ISKINCOHERENT(X, K) returns 1 if X is k-incoherent and 0 otherwise.
+%
+%   This function has no optional arguments.
 %
 %   URL: http://www.qetlab.com/IskIncoherent
 %
 %   References:
-%   [1] Ringbauer, Martin and Bromley, Thomas R. and Cianciaruso, Marco and Lami,
-%       Ludovico and Lau, W. Y. Sarah and Adesso, Gerardo and White, Andrew G. 
-%       and Fedrizzi, Alessandro and Piani, Marco. Certification and Quantification 
-%       of Multilevel Quantum Coherence. Phys. Rev. X, 8.041007, 2018.
+%   [1] M. Ringbauer, T. R. Bromley, M. Cianciaruso, L. Lami, W. Y. S. Lau, G.
+%       Adesso, A. G. White, A. Fedrizzi, and M. Piani. Certification and
+%       Quantification of Multilevel Quantum Coherence. Physical Review X 8
+%       (2018), no. 4, 041007. https://doi.org/10.1103/PhysRevX.8.041007.
 %   [2] N. Johnston, S. Moein, and S. Plosker. The factor width rank of a
 %       matrix. Linear Algebra and its Applications 716 (2025), 32–59.
 %       https://doi.org/10.1016/j.laa.2025.03.016.
@@ -22,20 +23,17 @@
 %   authors: Benjamin Talbot
 %            Luis M. B. Varona (lm.varona@outlook.com)
 %   package: QETLAB
-%   last updated: July 19, 2025
-
-
-% DOUBLE CHECK FOR THE COHERENCE NUMBER FROM THIS PAPER, MIGHT THROW OFF SOME OF MY ASSUMPTIONS
-
+%   last updated: July 21, 2025
 
 function iki = IskIncoherent(X, k)
     iki = -1;
+
     if k <= 0
         error('k must be a positive integer');
     end
 
     d = size(X,1);
-    
+
     % Trivial: every quantum state is d-incoherent
     if k == d
         iki = 1;
@@ -45,8 +43,10 @@ function iki = IskIncoherent(X, k)
     if isdiag(X)
         iki = 1;
         return
+    end
+
     % Trivial: only the diagonal quantum states are 1-incoherent
-    elseif k == 1
+    if k == 1
         iki = 0;
         return
     end
@@ -56,7 +56,8 @@ function iki = IskIncoherent(X, k)
     if IsPSD(M)
         iki = 1;
         return
-    elseif k == 2
+    end
+    if k == 2
         iki = 0;
         return
     end
@@ -84,63 +85,67 @@ function iki = IskIncoherent(X, k)
     if k >= 2
         iki = IskIncoherent(X, k-1);
     end
-
     if iki == -1
-        iki = IskIncoh(X, k);
+        iki = KIncohSemidefCheck(X, k);
     end
+end
 
-    %%  ISKINCOH    Determines whether or not a quantum state is k-incoherent
-    %   This function has two required arguments:
-    %     RHO: a mixed quantum state
-    %     K: a positive integer
-    %   
-    %   IKINC = IskCoherent(RHO,K) returns 1 if RHO is K-incoherent and return 0
-    %   otherwise. This is checked via semidefinite programming.
+%%  KIncohSemidefCheck    Determines whether or not a quantum state is k-incoherent
+%   This function has two required arguments:
+%     RHO: a mixed quantum state
+%     K: a positive integer
+%
+%   IKINC = KIncohSemidefCheck(RHO,K) returns 1 if RHO is K-incoherent and 0
+%   otherwise. This is checked via semidefinite programming.
 
-    %   requires: CVX (http://cvxr.com/cvx/)
-    %   author: Nathaniel Johnston (nathaniel@njohnston.ca), based on code and
-    %           conversations with Bartosz Regula
-    %   last updated: May 14, 2018
+%   requires: CVX (http://cvxr.com/cvx/)
+%   author: Nathaniel Johnston (nathaniel@njohnston.ca), based on code and
+%           conversations with Bartosz Regula
+%   last updated: July 21, 2025
 
-    function ikinc = IskIncoh(rho,k)
-        n = size(rho,1);
+function ikinc = KIncohSemidefCheck(rho,k)
+    n = size(rho,1);
 
-        Pk = nchoosek(1:n,k);
-        s = size(Pk,1);
+    Pk = nchoosek(1:n,k);
+    s = size(Pk,1);
 
-        cvx_begin sdp quiet
-        cvx_precision best;
-        variable A(k,k,s) hermitian;
-        subject to
-            P = zeros(n);
-            for j=1:s
-                proj = zeros(k,n);
-                for i = 1:k
-                    proj(i,Pk(j,i)) = 1;
-                end
-                P = P + proj'*A(:,:,j)*proj;
-                
-                A(:,:,j) >= 0;
+    cvx_begin sdp quiet
+    cvx_precision best;
+    variable A(k,k,s) hermitian;
+    subject to
+        P = zeros(n);
+
+        for j=1:s
+            proj = zeros(k,n);
+
+            for i = 1:k
+                proj(i,Pk(j,i)) = 1;
             end
-            rho == P;
-        cvx_end
-        
-        ikinc = 1-min(cvx_optval,1);
-    end
 
-    % Helper function to compute the comparison matrix
-    % defined as M(i,j) =  |X(i,j)| if i == j, and
-    %                     -|X(i,j)| if i ~= j
-    function M = ComparisonMatrix(A)
-        dim = size(A);
-        M = zeros(dim);
-        for i = 1:dim(1)
-            for j = 1:dim(2)
-                if i == j
-                    M(i,j) = abs(A(i,j));
-                else
-                    M(i,j) = -abs(A(i,j));
-                end
+            P = P + proj'*A(:,:,j)*proj;
+
+            A(:,:,j) >= 0;
+        end
+
+        rho == P;
+    cvx_end
+
+    ikinc = 1-min(cvx_optval,1);
+end
+
+% Helper function to compute the comparison matrix
+% defined as M(i,j) =  |X(i,j)| if i == j, and
+%                     -|X(i,j)| if i ~= j
+function M = ComparisonMatrix(A)
+    dim = size(A);
+    M = zeros(dim);
+
+    for i = 1:dim(1)
+        for j = 1:dim(2)
+            if i == j
+                M(i,j) = abs(A(i,j));
+            else
+                M(i,j) = -abs(A(i,j));
             end
         end
     end


### PR DESCRIPTION
This PR fixes the bug in `IskIncoherent` arising from nesting the CVX optimization problem (which created scoping issues for the variable `A`). It also fixes the docs to align better with the current implementation--previously, `-1` was sometimes returned when the function could not produce a definitive answer, but the addition of SDP ensures that we always find an answer. (References are also fixed/updated.)

Finally, `CHANGELOG.md` is updated to reflect both this and the bandwidth change from #34 (which forgot to update the changelog).