### PR TITLE
Add a `CITATION.bib`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Change Log
 All notable changes to QETLAB will be documented in this file.
 
-## Changes since v0.9 was released on 2016-01-12
+## Unreleased
+### Added
+- CITATION.bib: For citing QETLAB via BibTeX.
+
+## [1.0] - 2025-07-22
 ### Added
 - CliqueNumber: Bounds the clique number (i.e., maximum size of a clique) of a graph.
 - Concurrence: Computes the concurrence of a 2-qubit state.
@@ -46,7 +50,7 @@ All notable changes to QETLAB will be documented in this file.
 - Entropy: Improved numerical stability so that it no longer frequently returns NaN output.
 - GHZState: Now accepts DIM = 1 and/or Q = 1 as input.
 - IsBlockPositive: Fixed a numerical tolerance error that would sometimes cause incorrect results to be reported.
-- IskIncoherent: Fixed bug with nested CVX optimization and added a bandwidth check to sometimes return early. (Also fixed documentation.)
+- IskIncoherent: Fixed bug with nested CVX optimization and added a bandwidth check to sometimes return early. Also fixed documentation.
 - IsSeparable: Fixed a numerical tolerance error that would sometimes cause incorrect results to be reported.
 - Negativity: Users can now input either a pure state vector or a density matrix (previously, only density matrices were accepted).
 - NonlocalGameValue: Now computes classical value of a game quicker, via algorithm of arXiv:2005.13418

--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,0 +1,6 @@
+@misc{JCR14,
+  author = {Johnston, Nathaniel and Constentino, Alessandro and Russo, Vincent},
+  title = {nathanieljohnston/QETLAB: A MATLAB toolbox for quantum entanglement},
+  year = {2014},
+  url = {https://github.com/nathanieljohnston/QETLAB}
+}


### PR DESCRIPTION
This PR adds a `CITATION.bib` for easy citation by users. This is something that is done fairly regularly by repos whose intended audience is largely academia--see https://github.com/JuliaGraphs/Graphs.jl/blob/master/CITATION.bib, for example, or my own https://github.com/Luis-Varona/MatrixBandwidth.jl/blob/main/CITATION.bib. (Plus, a handy "Cite this repository" button pops up on the GitHub sidebar once this is added!)

Not sure if @nathanieljohnston would rather change this to refer to some specific Zenodo release instead, though. On that note...the current Zenodo DOI linked in `README.md` points to `v0.7` lol, not `v0.9` (the latest version to have a Zenodo release).