### PR TITLE
Update Zenodo badge in `README.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to QETLAB will be documented in this file.
 
+## Unreleased
+### Added
+- README.md: Update Zenodo badge to v0.9's submission
+
 ## [1.0] - 2025-07-22
 ### Added
 - CliqueNumber: Bounds the clique number (i.e., maximum size of a clique) of a graph.

--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ QETLAB is a MATLAB toolbox for exploring and manipulating quantum entanglement.
 * [QETLAB homepage](http://www.qetlab.com/)
 
 ## Citing
-[![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.14186.svg)](http://dx.doi.org/10.5281/zenodo.14186)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.44637.svg)](https://doi.org/10.5281/zenodo.44637)


### PR DESCRIPTION
As mentioned in #37, the Zenodo badge on the README currently points to the v0.7 submission, not the v0.9 submission. This commit fixes that. (v1.0 is not yet submitted to Zenodo; this is also something to consider @nathanieljohnston.)